### PR TITLE
Upgrade `minimist` to secure, latest patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-wdio": "^5.13.2",
     "eslint-watch": "^6.0.1",
+    "minimist": "^1.2.5",
     "request-promise-native": "^1.0.8",
     "wdio-chromedriver-service": "^5.0.2",
     "wdio-timeline-reporter": "^5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,6 +3552,11 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"


### PR DESCRIPTION
Until `csv-parser` has a patch for the new vulnerability, we need to manually request a newer version of this lib, while avoiding other updates that currently cause test compatibility issues