### PR TITLE
REG-11 - shuffle around radio element IDs

### DIFF
--- a/pages/DonateStartPage.js
+++ b/pages/DonateStartPage.js
@@ -19,12 +19,17 @@ const startPageStripe = process.env.DONATE_PAGE_STRIPE;
 // selectors
 const submitBtnSelector = 'button*=Donate ';
 const donationAmountSelector = '#donationAmount';
-const claimGiftAidSelector = '#mat-radio-3';
+// Now we show the Gift Aid section conditionally, this is mounted last
+// and the ratio gets the highest ID.
+// TODO avoid these hacks for radio selectors! We should be checking copy
+// ideally, although we also need to maintain IE11 support for this journey
+// so can't necessarily use standard Xpath. :/
+const claimGiftAidSelector = '#mat-radio-9';
 const firstNameSelector = '#firstName';
 const lastNameSelector = '#lastName';
 const emailAddressSelector = '#emailAddress';
-const receiveEmailFromCharitySelector = '#mat-radio-6';
-const receiveEmailFromTheBigGiveSelector = '#mat-radio-9';
+const receiveEmailFromCharitySelector = '#mat-radio-3';
+const receiveEmailFromTheBigGiveSelector = '#mat-radio-6';
 const billingPostcodeSelector = '#billingPostcode';
 const stripeCardNumberSelector = 'input[name$="cardnumber"]';
 const stripeExpiryDateSelector = 'input[name$="exp-date"]';

--- a/pages/PledgeFormPage.js
+++ b/pages/PledgeFormPage.js
@@ -62,7 +62,7 @@ export default class PledgeFormPage {
      * @param {string}  amount  Whole number of pounds
      */
     setPledgeAmount(amount) {
-        inputSelectorValue(this.getCommunitiesInputForLabel('Pledge amount (£)'), amount);
+        inputSelectorValue(this.getCommunitiesInputForLabel('Pledge amount'), amount);
     }
 
     /**


### PR DESCRIPTION
As we are using brittle numeric selectors for the moment,
the change to rendering the Gift Aid step conditionally
(only when donating in GBP) has changed the specific
ID values we need to use.

Field label `Pledge amount (£)` has also changed to remove the suffix,
so the test populating that input needed its selector updating.