### PR TITLE
Includ email subjects found in error message when subject is wrong or missing

### DIFF
--- a/steps/donation.js
+++ b/steps/donation.js
@@ -290,8 +290,7 @@ Then(
 Then(
     /^I should recieve a registration success email with the email I donated with$/,
     async () => {
-        // test broken on purpose to let us see failure:
-        checkAnEmailSubjectContainsText('Subject that the email doesn\'t contain');
+        checkAnEmailSubjectContainsText('You are registered with Big Give');
 
         // eslint-disable-next-line max-len
         const expectedCopy = `You are now registered for Big Give with the email address: ${donor.email}`;

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -290,11 +290,7 @@ Then(
 Then(
     /^I should recieve a registration success email with the email I donated with$/,
     async () => {
-        if (!(await checkAnEmailSubjectContainsText(
-            'You are registered with Big Give'
-        ))) {
-            throw new Error('Registration email subject not found.');
-        }
+        checkAnEmailSubjectContainsText('You are registered with Big Give');
 
         // eslint-disable-next-line max-len
         const expectedCopy = `You are now registered for Big Give with the email address: ${donor.email}`;

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -290,7 +290,8 @@ Then(
 Then(
     /^I should recieve a registration success email with the email I donated with$/,
     async () => {
-        checkAnEmailSubjectContainsText('You are registered with Big Give');
+        // test broken on purpose to let us see failure:
+        checkAnEmailSubjectContainsText('Subject that the email doesn\'t contain');
 
         // eslint-disable-next-line max-len
         const expectedCopy = `You are now registered for Big Give with the email address: ${donor.email}`;

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -129,8 +129,6 @@ Then(
 Then(
     /^my last email subject should contain "(.+)"$/,
     async (subjectText) => {
-        if (!(await checkAnEmailSubjectContainsText(subjectText))) {
-            throw new Error(`"${subjectText}" not found in email subject`);
-        }
+        checkAnEmailSubjectContainsText(subjectText);
     }
 );

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -66,22 +66,24 @@ export async function checkAnEmailBodyContainsText(searchText) {
 /**
  * Checks one of the latest emails' subject line contains the expected text.
  *
- * Be sure to `await` any results that should impact test pass/fail status!
+ * Throws if the subject was not found.
  *
  * @param {string} searchText   Text to expect in latest subject line.
- * @returns {boolean}           Whether the text was found.
+ * @returns {void}
  */
 export async function checkAnEmailSubjectContainsText(searchText) {
     const messages = await getLatestMessages();
     if (messages.length === 0) {
-        return false;
+        throw new Error('No email messages found');
     }
 
     for (let ii = 0; ii < messages.length; ii += 1) {
         if (messages[ii].subject.includes(searchText)) {
-            return true;
+            return;
         }
     }
 
-    return false;
+    const joinedSubjects = messages.map((m) => m.subject).join(', ');
+
+    throw new Error(`"${searchText}" not found in email subjects: "${joinedSubjects}"`);
 }


### PR DESCRIPTION
We had tests fail several times last night with this error, but since it didn't report the subject line(s) found it's hard to tell what the error was. It's started passing again now. This more detailed error message should help us fix it if it happens again.