### PR TITLE
retrieve only relavent emails from mailtrap

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -37,7 +37,7 @@ rules:
     - SwitchCase: 1
   max-len:
     - 'error'
-    - 100
+    - 120
     - ignorePattern: '\s*\/\^(.*)\$\/,$'
   new-cap:
     - 'error'

--- a/pages/DonateStartPage.js
+++ b/pages/DonateStartPage.js
@@ -56,12 +56,6 @@ export default class DonateStartPage {
         this.browser = browser;
         this.nextStepIndex = 0;
         this.charity = null;
-
-        this.firstName = generateIdentifier('Firstname-');
-        this.lastName = generateIdentifier('Lastname-');
-        // This enforces the email to always be unique, so the test to create an account works
-        // because we never hit the error of the email already being used by another used. REG-26.
-        this.email = `${generateIdentifier('tech+regression+tests+')}@thebiggivetest.org.uk`;
     }
 
     /**
@@ -171,12 +165,16 @@ export default class DonateStartPage {
      * Enter first & last name and email address, in Stripe mode.
      */
     async populateNameAndEmail() {
-        const { firstName, lastName, email } = this;
+        const firstName = generateIdentifier('Firstname-');
+        const lastName = generateIdentifier('Lastname-');
+        // This enforces the email to always be unique, so the test to create an account works
+        // because we never hit the error of the email already being used by another used. REG-26.
+        const email = `${generateIdentifier('tech+regression+tests+')}@thebiggivetest.org.uk`;
+
         await inputSelectorValue(firstNameSelector, firstName);
         await inputSelectorValue(lastNameSelector, lastName);
         // Mailer is configured in the Regression environment to send mail via Mailtrap.io's
         // fake SMTP server, regardless of the donor's given email address.
-
         await inputSelectorValue(emailAddressSelector, email);
 
         return {

--- a/pages/DonateStartPage.js
+++ b/pages/DonateStartPage.js
@@ -56,6 +56,12 @@ export default class DonateStartPage {
         this.browser = browser;
         this.nextStepIndex = 0;
         this.charity = null;
+
+        this.firstName = generateIdentifier('Firstname-');
+        this.lastName = generateIdentifier('Lastname-');
+        // This enforces the email to always be unique, so the test to create an account works
+        // because we never hit the error of the email already being used by another used. REG-26.
+        this.email = `${generateIdentifier('tech+regression+tests+')}@thebiggivetest.org.uk`;
     }
 
     /**
@@ -165,16 +171,12 @@ export default class DonateStartPage {
      * Enter first & last name and email address, in Stripe mode.
      */
     async populateNameAndEmail() {
-        const firstName = generateIdentifier('Firstname-');
-        const lastName = generateIdentifier('Lastname-');
-        // This enforces the email to always be unique, so the test to create an account works
-        // because we never hit the error of the email already being used by another used. REG-26.
-        const email = `${generateIdentifier('tech+regression+tests+')}@thebiggivetest.org.uk`;
-
+        const { firstName, lastName, email } = this;
         await inputSelectorValue(firstNameSelector, firstName);
         await inputSelectorValue(lastNameSelector, lastName);
         // Mailer is configured in the Regression environment to send mail via Mailtrap.io's
         // fake SMTP server, regardless of the donor's given email address.
+
         await inputSelectorValue(emailAddressSelector, email);
 
         return {

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -233,7 +233,7 @@ Then(
     async () => {
         if (!(await checkAnEmailBodyContainsText(
             `Donation: <strong>£${donationAmount}.00</strong>`,
-            page.email
+            donor.email
         ))) {
             throw new Error(`Donation amount £${donationAmount} not found in email`);
         }
@@ -243,7 +243,7 @@ Then(
 Then(
     'my last email should contain the charity\'s custom thank you message',
     async () => {
-        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS, page.email))) {
+        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS, donor.email))) {
             throw new Error('Charity thank you message not found in email');
         }
     }
@@ -254,7 +254,7 @@ Then(
     async () => {
         if (!(await checkAnEmailBodyContainsText(
             `Donor: <strong>${donor.firstName} ${donor.lastName}</strong>`,
-            page.email,
+            donor.email,
         ))) {
             throw new Error(`Donor name ${donor.firstName} ${donor.lastName} not found in email`);
         }
@@ -299,7 +299,7 @@ Then(
 
         if (!(await checkAnEmailBodyContainsText(
             expectedCopy,
-            page.email
+            donor.email
         ))) {
             throw new Error(`Registration email with expected copy not found.
             Expected: ${expectedCopy}`);

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -232,7 +232,8 @@ Then(
     'my last email should contain the correct amounts',
     async () => {
         if (!(await checkAnEmailBodyContainsText(
-            `Donation: <strong>£${donationAmount}.00</strong>`
+            `Donation: <strong>£${donationAmount}.00</strong>`,
+            donor.email
         ))) {
             throw new Error(`Donation amount £${donationAmount} not found in email`);
         }
@@ -242,7 +243,7 @@ Then(
 Then(
     'my last email should contain the charity\'s custom thank you message',
     async () => {
-        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS))) {
+        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS, donor.email))) {
             throw new Error('Charity thank you message not found in email');
         }
     }
@@ -252,7 +253,8 @@ Then(
     'my last email should contain the correct name',
     async () => {
         if (!(await checkAnEmailBodyContainsText(
-            `Donor: <strong>${donor.firstName} ${donor.lastName}</strong>`
+            `Donor: <strong>${donor.firstName} ${donor.lastName}</strong>`,
+            donor.email,
         ))) {
             throw new Error(`Donor name ${donor.firstName} ${donor.lastName} not found in email`);
         }
@@ -296,7 +298,8 @@ Then(
         const expectedCopy = `You are now registered for Big Give with the email address: ${donor.email}`;
 
         if (!(await checkAnEmailBodyContainsText(
-            expectedCopy
+            expectedCopy,
+            donor.email
         ))) {
             throw new Error(`Registration email with expected copy not found.
             Expected: ${expectedCopy}`);

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -233,7 +233,7 @@ Then(
     async () => {
         if (!(await checkAnEmailBodyContainsText(
             `Donation: <strong>£${donationAmount}.00</strong>`,
-            donor.email
+            page.email
         ))) {
             throw new Error(`Donation amount £${donationAmount} not found in email`);
         }
@@ -243,7 +243,7 @@ Then(
 Then(
     'my last email should contain the charity\'s custom thank you message',
     async () => {
-        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS, donor.email))) {
+        if (!(await checkAnEmailBodyContainsText(process.env.CHARITY_CUSTOM_THANKS, page.email))) {
             throw new Error('Charity thank you message not found in email');
         }
     }
@@ -254,7 +254,7 @@ Then(
     async () => {
         if (!(await checkAnEmailBodyContainsText(
             `Donor: <strong>${donor.firstName} ${donor.lastName}</strong>`,
-            donor.email,
+            page.email,
         ))) {
             throw new Error(`Donor name ${donor.firstName} ${donor.lastName} not found in email`);
         }
@@ -299,7 +299,7 @@ Then(
 
         if (!(await checkAnEmailBodyContainsText(
             expectedCopy,
-            donor.email
+            page.email
         ))) {
             throw new Error(`Registration email with expected copy not found.
             Expected: ${expectedCopy}`);

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -292,7 +292,7 @@ Then(
 Then(
     /^I should recieve a registration success email with the email I donated with$/,
     async () => {
-        checkAnEmailSubjectContainsText('You are registered with Big Give');
+        checkAnEmailSubjectContainsText('You are registered with Big Give', donor.email);
 
         // eslint-disable-next-line max-len
         const expectedCopy = `You are now registered for Big Give with the email address: ${donor.email}`;

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -35,6 +35,7 @@ When(
     /^I enter a pledge amount between £([0-9]+) and £([0-9]+)$/,
     async (minAmount, maxAmount) => {
         pledgeAmount = randomIntFromInterval(Number(minAmount), Number(maxAmount));
+        console.log(`Randomly selected ${pledgeAmount} as between ${minAmount} and ${maxAmount}`);
         await page.setPledgeAmount(pledgeAmount);
     }
 );

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -119,7 +119,7 @@ Then(
         const expectedBody = 'Thank you for your generous match funding pledge of '
             + `£${pledgeAmount}.00 to `
             + 'Exempt Stripe Test Charity for the campaign: Submit a pledge of funds';
-        if (await checkAnEmailBodyContainsText(expectedBody)) {
+        if (await checkAnEmailBodyContainsText(expectedBody, emailAddress)) {
             console.log(`CHECK: Email refers to £${pledgeAmount} pledge and correct campaign`);
         } else {
             throw new Error(`Pledge amount £${pledgeAmount} or details not found in email`);

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -130,6 +130,6 @@ Then(
 Then(
     /^my last email subject should contain "(.+)"$/,
     async (subjectText) => {
-        checkAnEmailSubjectContainsText(subjectText);
+        checkAnEmailSubjectContainsText(subjectText, emailAddress);
     }
 );

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -83,8 +83,8 @@ When(
 When(
     'I give a valid pledger email address',
     async () => {
-        emailAddress = `pledger+${randomIntFromInterval(1, 9999999)}@thebiggivetest.org.uk`;
-        await page.setPledgerEmail('Email', emailAddress);
+        page.emailAddress = `pledger+${randomIntFromInterval(1, 9999999)}@thebiggivetest.org.uk`;
+        await page.setPledgerEmail('Email', page.emailAddress);
     }
 );
 
@@ -119,7 +119,7 @@ Then(
         const expectedBody = 'Thank you for your generous match funding pledge of '
             + `£${pledgeAmount}.00 to `
             + 'Exempt Stripe Test Charity for the campaign: Submit a pledge of funds';
-        if (await checkAnEmailBodyContainsText(expectedBody, emailAddress)) {
+        if (await checkAnEmailBodyContainsText(expectedBody, page.email)) {
             console.log(`CHECK: Email refers to £${pledgeAmount} pledge and correct campaign`);
         } else {
             throw new Error(`Pledge amount £${pledgeAmount} or details not found in email`);

--- a/steps/pledge.js
+++ b/steps/pledge.js
@@ -83,8 +83,8 @@ When(
 When(
     'I give a valid pledger email address',
     async () => {
-        page.emailAddress = `pledger+${randomIntFromInterval(1, 9999999)}@thebiggivetest.org.uk`;
-        await page.setPledgerEmail('Email', page.emailAddress);
+        emailAddress = `pledger+${randomIntFromInterval(1, 9999999)}@thebiggivetest.org.uk`;
+        await page.setPledgerEmail('Email', emailAddress);
     }
 );
 
@@ -119,7 +119,7 @@ Then(
         const expectedBody = 'Thank you for your generous match funding pledge of '
             + `£${pledgeAmount}.00 to `
             + 'Exempt Stripe Test Charity for the campaign: Submit a pledge of funds';
-        if (await checkAnEmailBodyContainsText(expectedBody, page.email)) {
+        if (await checkAnEmailBodyContainsText(expectedBody, emailAddress)) {
             console.log(`CHECK: Email refers to £${pledgeAmount} pledge and correct campaign`);
         } else {
             throw new Error(`Pledge amount £${pledgeAmount} or details not found in email`);

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -22,10 +22,12 @@ async function mailtrapGet(path, responseType) {
  * Get the latest Mailtrap inbox message, if any.
  *
  * @param {int} count  Number of recent emails to get.
+ * @param {string} toEmailAddress Only find emails addressed to this account
  * @returns {array}     Up to {{count}} messages, if available.
  */
-async function getLatestMessages(count = 5) {
-    const path = `/api/v1/inboxes/${process.env.MAILTRAP_INBOX_ID}/messages?search=&page=&last_id=`;
+async function getLatestMessages(count = 5, toEmailAddress) {
+    const params = new URLSearchParams({ search: toEmailAddress, page: '', last_id: '' });
+    const path = `/api/v1/inboxes/${process.env.MAILTRAP_INBOX_ID}/messages?${params.toString()}`;
     const messages = await mailtrapGet(path, 'json');
     if (messages.length === 0) {
         return [];
@@ -40,10 +42,12 @@ async function getLatestMessages(count = 5) {
  * Be sure to `await` any results that should impact test pass/fail status!
  *
  * @param {string} searchText   Expected text to find anywhere in HTML
+ * @param {string} toEmailAddress Only find emails addressed to this account
+ *              (or an account that starts with this)
  * @returns {boolean}       Whether the expected text was found.
  */
-export async function checkAnEmailBodyContainsText(searchText) {
-    const messages = await getLatestMessages();
+export async function checkAnEmailBodyContainsText(searchText, toEmailAddress) {
+    const messages = await getLatestMessages(toEmailAddress);
     if (messages.length === 0) {
         return false;
     }
@@ -69,10 +73,11 @@ export async function checkAnEmailBodyContainsText(searchText) {
  * Throws if the subject was not found.
  *
  * @param {string} searchText   Text to expect in latest subject line.
+ * @param {string} toEmailAddress Only find emails addressed to this account
  * @returns {void}
  */
-export async function checkAnEmailSubjectContainsText(searchText) {
-    const messages = await getLatestMessages();
+export async function checkAnEmailSubjectContainsText(searchText, toEmailAddress) {
+    const messages = await getLatestMessages(toEmailAddress);
     if (messages.length === 0) {
         throw new Error('No email messages found');
     }

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -21,11 +21,10 @@ async function mailtrapGet(path, responseType) {
 /**
  * Get the latest Mailtrap inbox message, if any.
  *
- * @param {int} count  Number of recent emails to get.
  * @param {string} toEmailAddress Only find emails addressed to this account
  * @returns {array}     Up to {{count}} messages, if available.
  */
-async function getLatestMessages(count = 5, toEmailAddress) {
+async function getLatestMessages(toEmailAddress) {
     if (typeof toEmailAddress !== 'string') {
         throw new Error(`Expected toEmailAddress to be string, was ${typeof toEmailAddress}: ${toEmailAddress}`);
     }
@@ -40,7 +39,8 @@ async function getLatestMessages(count = 5, toEmailAddress) {
         return [];
     }
 
-    return messages.slice(0, count); // Latest e.g. 5 emails.
+    const count = 5;
+    return messages.slice(0, count); // Latest emails.
 }
 
 /**

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -26,6 +26,10 @@ async function mailtrapGet(path, responseType) {
  * @returns {array}     Up to {{count}} messages, if available.
  */
 async function getLatestMessages(count = 5, toEmailAddress) {
+    if (typeof toEmailAddress !== 'string') {
+        throw new Error(`Expected toEmailAddress to be string, was ${typeof toEmailAddress}: ${toEmailAddress}`);
+    }
+
     const params = new URLSearchParams({ search: toEmailAddress, page: '', last_id: '' });
     const path = `/api/v1/inboxes/${process.env.MAILTRAP_INBOX_ID}/messages?${params.toString()}`;
     const messages = await mailtrapGet(path, 'json');

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -29,6 +29,9 @@ async function getLatestMessages(count = 5, toEmailAddress) {
     const params = new URLSearchParams({ search: toEmailAddress, page: '', last_id: '' });
     const path = `/api/v1/inboxes/${process.env.MAILTRAP_INBOX_ID}/messages?${params.toString()}`;
     const messages = await mailtrapGet(path, 'json');
+
+    console.log(`got ${messages.length} message(s) from mailtrap at path ${path}`);
+
     if (messages.length === 0) {
         return [];
     }

--- a/support/mailtrap.js
+++ b/support/mailtrap.js
@@ -29,10 +29,9 @@ async function getLatestMessages(toEmailAddress) {
         throw new Error(`Expected toEmailAddress to be string, was ${typeof toEmailAddress}: ${toEmailAddress}`);
     }
 
-    const params = new URLSearchParams({ search: toEmailAddress, page: '', last_id: '' });
+    const params = new URLSearchParams({ search: toEmailAddress });
     const path = `/api/v1/inboxes/${process.env.MAILTRAP_INBOX_ID}/messages?${params.toString()}`;
     const messages = await mailtrapGet(path, 'json');
-
     console.log(`got ${messages.length} message(s) from mailtrap at path ${path}`);
 
     if (messages.length === 0) {


### PR DESCRIPTION
I hope this should prevent repeats of some or all of the recent errors that we have seen from regression tests. By specifying the to_email of interest when we query emails in mailtrap we should significantly reduce the chance of not seeing the emails we need to check.