### PR TITLE
DON-787: Run test against old and new stepper versions

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -50,5 +50,4 @@ rules:
   valid-jsdoc:
     - 'error'
     - requireReturn: false
-      matchDescription: '.+'
   no-console: 'off'

--- a/features/donation-as-new-donor-restart-donation.feature
+++ b/features/donation-as-new-donor-restart-donation.feature
@@ -4,8 +4,8 @@ Feature: New donor: restarting donation completes successfully
     I want payment to be taken for a match campaign for a Stripe charity even if I change the amounts after initial selection
     So that I can support my chosen charity with a doubled donation
 
-    Scenario: New donor: restarting donation completes successfully
-        Given that I am on my chosen Stripe-enabled charity's Donate page
+    Scenario Outline: New donor: restarting donation completes successfully
+        Given that I am on my chosen Stripe-enabled charity's <stepper-version> Donate page
         And I close the cookie notice if shown
         When I enter an amount between £5 and £25,000
         And I choose a preference for Gift Aid
@@ -22,3 +22,8 @@ Feature: New donor: restarting donation completes successfully
         Then my last email should contain the correct amounts
         And my last email should contain the charity's custom thank you message
         And my last email should contain the correct name
+
+        Examples:
+            | stepper-version |
+            | new             |
+            | old             |

--- a/features/donation-as-new-donor-then-register.feature
+++ b/features/donation-as-new-donor-then-register.feature
@@ -4,8 +4,8 @@ Feature: New donor: donation completes successfully and donor registers
     I want payment to be taken for a match campaign for a Stripe charity
     So that I can support my chosen charity with a doubled donation
 
-    Scenario: New donor: donation completes successfully and donor registers
-        Given that I am on my chosen Stripe-enabled charity's Donate page
+    Scenario Outline: New donor: donation completes successfully and donor registers
+        Given that I am on my chosen Stripe-enabled charity's <stepper-version> Donate page
         And I close the cookie notice if shown
         When I enter an amount between £5 and £25,000
         And I choose a preference for Gift Aid
@@ -27,3 +27,7 @@ Feature: New donor: donation completes successfully and donor registers
 #        Then the page should update to say I'm registered
 #        When I wait a few seconds
 #        Then I should recieve a registration success email with the email I donated with
+        Examples:
+            | stepper-version |
+            | new             |
+            | old             |

--- a/features/donation-with-credits.feature
+++ b/features/donation-with-credits.feature
@@ -5,8 +5,8 @@ Feature: Existing donor: credit donation completes successfully
     I want payment to be taken for a match campaign for a Stripe charity using my donation credits (Stripe cash balance)
     So that I can support my chosen charity with a doubled donation
 
-    Scenario: Existing donor: credit donation completes successfully
-        Given that I am on my chosen Stripe-enabled charity's Donate page
+    Scenario Outline: Existing donor: credit donation completes successfully
+        Given that I am on my chosen Stripe-enabled charity's <stepper-version> Donate page
         And I close the cookie notice if shown
         And I click the "Log in" button
         And I enter the ID credit-funded account test email and password
@@ -27,3 +27,8 @@ Feature: Existing donor: credit donation completes successfully
         Then my last email should contain the correct amounts
         And my last email should contain the charity's custom thank you message
         And my last email should contain the correct name
+
+        Examples:
+            | stepper-version |
+            | new             |
+            | old             |

--- a/features/donation-with-saved-info.feature
+++ b/features/donation-with-saved-info.feature
@@ -5,8 +5,8 @@ Feature: Existing donor: saved payment method donation completes successfully
     I want payment to be taken for a match campaign for a Stripe charity with less manual input by me
     So that I can support my chosen charity with a doubled donation
 
-    Scenario: Existing donor: saved payment method donation completes successfully
-        Given that I am on my chosen Stripe-enabled charity's Donate page
+    Scenario Outline: Existing donor: saved payment method donation completes successfully
+        Given that I am on my chosen Stripe-enabled charity's <stepper-version> Donate page
         And I close the cookie notice if shown
         And I click the "Log in" button
         And I enter the ID account test email and password
@@ -26,3 +26,7 @@ Feature: Existing donor: saved payment method donation completes successfully
         Then my last email should contain the correct amounts
         And my last email should contain the charity's custom thank you message
         And my last email should contain the correct name
+        Examples:
+            | stepper-version |
+            | new             |
+            | old             |

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -18,6 +18,8 @@ import DonateSuccessPage from '../pages/DonateSuccessPage';
  */
 let donationAmount = randomIntFromInterval(5, 100);
 let donor = {};
+
+/** @type DonateStartPage * */
 let page;
 // eslint-disable-next-line new-cap
 BeforeAll(() => {
@@ -26,9 +28,10 @@ BeforeAll(() => {
 
 // Steps
 Given(
-    /^that I am on my chosen ([a-zA-Z]+)-enabled charity's Donate page$/,
-    async (psp) => {
-        await page.open(psp);
+    /^that I am on my chosen ([a-zA-Z]+)-enabled charity's ([a-zA-Z]+) Donate page$/,
+    async (psp, stepperVersion) => {
+        page.nextStepIndex = 0;
+        await page.open(psp, stepperVersion);
         await page.checkReady();
     }
 );


### PR DESCRIPTION
Failing just because of a duplicate id found on the new donate start page. Seems to be an auto generated ID, different each time it runs. I'm tempted to give up and set the tests to allow duplicate IDs unless anyone else can find what's causing it.

There are lots of commits, because I had to push each one to circle to see if it worked. I'll rebase them all down to one before merging. I suggest just reviewing the overall diff, not each commit unless you're a completist.