### PR TITLE
DON-950: Add regression test check for server side rendering

### DIFF
--- a/features/server-side-rendering.feature
+++ b/features/server-side-rendering.feature
@@ -1,0 +1,8 @@
+Feature: The site is rendered server side
+
+  We use server side rendering to make the site faster to use for people and easier for search engines to index.
+
+  Scenario: Homepage is server side rendered
+    Given I am loading the site without Javascript
+    When I view the homepage
+    Then I should see in the source "Double the difference"

--- a/steps/ssr.js
+++ b/steps/ssr.js
@@ -14,12 +14,7 @@ Given(/^I am loading the site without Javascript$/, async () => {
 });
 
 When(/^I view the homepage$/, async () => {
-    const client = axios.create({
-        baseURL: 'https://mailtrap.io',
-        headers: {
-            'Api-Token': process.env.MAILTRAP_API_TOKEN,
-        },
-    });
+    const client = axios.create();
     url = process.env.BASE_URL;
     pageContent = (await client.get(url)).data;
 });

--- a/steps/ssr.js
+++ b/steps/ssr.js
@@ -1,0 +1,31 @@
+import {
+    Given, When, Then
+} from '@cucumber/cucumber';
+import axios from 'axios';
+
+/** @type {string} */
+let pageContent;
+
+/** @type {string} */
+let url;
+
+Given(/^I am loading the site without Javascript$/, async () => {
+    // no-op
+});
+
+When(/^I view the homepage$/, async () => {
+    const client = axios.create({
+        baseURL: 'https://mailtrap.io',
+        headers: {
+            'Api-Token': process.env.MAILTRAP_API_TOKEN,
+        },
+    });
+    url = process.env.BASE_URL;
+    pageContent = (await client.get(url)).data;
+});
+
+Then(/^I should see in the source "([^"]*)"$/, (phrase) => {
+    if (!pageContent.includes(phrase)) {
+        throw new Error(`Expected "${phrase}" not found in source code at ${url}`);
+    }
+});


### PR DESCRIPTION
Other tests are failing for unrelated reasons, but this new one is passing:

```
[chrome 117.0.5938.89 windows #0-4] Running: chrome (v117.0.5938.89) on windows
[chrome 117.0.5938.89 windows #0-4] Session ID: 1b9b1fa08735-5829bf74be9b-be36fce7ae6e-171222908495-16840990
[chrome 117.0.5938.89 windows #0-4]
[chrome 117.0.5938.89 windows #0-4] » /features/server-side-rendering.feature
[chrome 117.0.5938.89 windows #0-4] The site is rendered server side
[chrome 117.0.5938.89 windows #0-4] We use server side rendering to make the site faster to use for people and easier for search engines to index.
[chrome 117.0.5938.89 windows #0-4]
[chrome 117.0.5938.89 windows #0-4] Homepage is server side rendered
[chrome 117.0.5938.89 windows #0-4]    ✓ Given I am loading the site without Javascript
[chrome 117.0.5938.89 windows #0-4]    ✓ When I view the homepage
[chrome 117.0.5938.89 windows #0-4]    ✓ Then I should see in the source "Double the difference"
[chrome 117.0.5938.89 windows #0-4]
[chrome 117.0.5938.89 windows #0-4] 3 passing (833ms)
```