### PR TITLE
DON-965: Make tests clearer by removing code to close cookie notice

### DIFF
--- a/features/donation-as-new-donor-restart-donation.feature
+++ b/features/donation-as-new-donor-restart-donation.feature
@@ -6,7 +6,6 @@ Feature: New donor: restarting donation completes successfully
 
     Scenario: New donor: restarting donation completes successfully
         Given that I am on my chosen Stripe-enabled charity's Donate page
-        And I close the cookie notice if shown
         When I enter an amount between £5 and £25,000
         And I choose a preference for Gift Aid
         And I enter my name, email address and Stripe payment details
@@ -26,5 +25,4 @@ Feature: New donor: restarting donation completes successfully
 
         Given that I am on my chosen Stripe-enabled charity's Donate page
          # And I didn't set a password above, or log-in
-        And I close the cookie notice if shown
         Then I should be invited to log in

--- a/features/donation-as-new-donor-then-register.feature
+++ b/features/donation-as-new-donor-then-register.feature
@@ -6,7 +6,6 @@ Feature: New donor: donation completes successfully and donor registers
 
     Scenario: New donor: donation completes successfully and donor registers
         Given that I am on my chosen Stripe-enabled charity's Donate page
-        And I close the cookie notice if shown
         When I enter an amount between £5 and £25,000
         And I choose a preference for Gift Aid
         And I enter my name, email address and Stripe payment details

--- a/features/donation-with-credits.feature
+++ b/features/donation-with-credits.feature
@@ -6,7 +6,6 @@ Feature: Existing donor: credit donation completes successfully
 
     Scenario: Existing donor: credit donation completes successfully
         Given that I am on my chosen Stripe-enabled charity's Donate page
-        And I close the cookie notice if shown
         And I click the "Log in" button
         And I enter the ID credit-funded account test email and password
         And I click the popup's login button

--- a/features/donation-with-saved-info.feature
+++ b/features/donation-with-saved-info.feature
@@ -6,7 +6,6 @@ Feature: Existing donor: saved payment method donation completes successfully
 
     Scenario: Existing donor: saved payment method donation completes successfully
         Given that I am on my chosen Stripe-enabled charity's Donate page
-        And I close the cookie notice if shown
         And I click the "Log in" button
         And I enter the ID account test email and password
         And I click the popup's login button

--- a/features/submit-pledge.feature
+++ b/features/submit-pledge.feature
@@ -6,7 +6,6 @@ Feature: Pledge form is submitted successfully
 
   Scenario: Pledge form is submitted successfully
     Given I open the pledge campaign's pledge form
-    And I close the cookie notice if shown
     Then I should see a Communities hero banner saying "Thank you for choosing to pledge to Exempt Stripe Test Charity"
     When I enter a pledge amount between £100 and £110
     And I choose to pay my pledge by Bank Transfer

--- a/steps/donation.js
+++ b/steps/donation.js
@@ -6,7 +6,7 @@ import {
 } from '@cucumber/cucumber';
 
 import { checkAnEmailBodyContainsText, checkAnEmailSubjectContainsText } from '../support/mailtrap';
-import { closeCookieNotice, randomIntFromInterval } from '../support/util';
+import { randomIntFromInterval } from '../support/util';
 import DonateStartPage from '../pages/DonateStartPage';
 import DonateSuccessPage from '../pages/DonateSuccessPage';
 import { checkVisibleSelectorContent } from '../support/check';
@@ -36,11 +36,6 @@ Given(
         await page.open();
         await page.checkReady();
     }
-);
-
-When(
-    'I close the cookie notice if shown',
-    closeCookieNotice,
 );
 
 When("I click the popup's login button", async () => {

--- a/support/util.js
+++ b/support/util.js
@@ -1,6 +1,3 @@
-import { clickSelector } from './action';
-import { elementExists } from './check';
-
 /**
  * Go to URL
  *
@@ -13,22 +10,6 @@ export async function goToUrl(url) {
     } catch (error) {
         throw new Error(`error trying to go to URL: ${url}: ${error}`);
     }
-}
-
-/**
- * Close cookie notice if it's shown, so it doesn't steal focus by being fixed on top of
- * other elements.
- */
-export async function closeCookieNotice() {
-    const selector = 'w-div > span:last-child'; // Cookie banner close button
-
-    if (!(await elementExists(selector))) {
-        console.log('No cookie notice to close');
-        return;
-    }
-
-    await clickSelector(selector);
-    console.log('Closed cookie notice');
 }
 
 /**


### PR DESCRIPTION
If we want these feature files to be real BDD style tests that we can ask non-developers to read then we need to make sure they express the core requriements as clearly as possible and have little to no accidental complexity reflected in the actual feature files.

Since frontend is now specifically not showing cookie notices in the regression environment we don't need to deal with them here.