### PR TITLE
Revert "MAT-363: Allow extra 30s for thank you email to be sent"

### DIFF
--- a/steps/donation.js
+++ b/steps/donation.js
@@ -223,7 +223,7 @@ When(
     'I wait long enough for email processing',
     // 35s to allow SF + Mailtrap time to process everything
     // eslint-disable-next-line wdio/no-pause
-    async () => browser.pause(95 * 1000)
+    async () => browser.pause(35 * 1000)
 );
 
 Then('I should be invited to log in', async () => {


### PR DESCRIPTION
Reverts thebiggive/regression-tests#150

That lead to an error "Error: function timed out, ensure the promise resolves within 90000 milliseconds".

In other cucumber doesn't allow any step to take more than 90 seconds.