### PR TITLE
TestingBot config: Specify browser version as latest instead of hardcoded versions

### DIFF
--- a/wdio.testingbot-all.conf.js
+++ b/wdio.testingbot-all.conf.js
@@ -4,13 +4,13 @@ config.capabilities = [
     {
         browserName: 'chrome',
         platform: 'WIN11',
-        version: '117',
+        version: 'latest',
         build: config.build,
     },
     {
         browserName: 'microsoftedge',
         platform: 'WIN11',
-        version: '117',
+        version: 'latest',
         build: config.build,
         // MS Edge, like IE, seems to also have problems with scroll mgmt behaviour.
         // https://stackoverflow.com/questions/52276194

--- a/wdio.testingbot-chrome.conf.js
+++ b/wdio.testingbot-chrome.conf.js
@@ -3,7 +3,7 @@ const { config } = require('./wdio.BASE.conf.ts');
 config.capabilities = [{
     browserName: 'chrome',
     platform: 'WIN11',
-    version: '117',
+    version: 'latest',
     build: config.build,
 }];
 config.services.push('testingbot');

--- a/wdio.testingbot-edge.conf.js
+++ b/wdio.testingbot-edge.conf.js
@@ -3,7 +3,7 @@ const { config } = require('./wdio.BASE.conf.ts');
 config.capabilities = [{
     browserName: 'microsoftedge',
     platform: 'WIN11',
-    version: '117',
+    version: 'latest',
     build: config.build,
     // MS Edge, like IE, seems to also have problems with scroll mgmt behaviour.
     // https://stackoverflow.com/questions/52276194


### PR DESCRIPTION
Hi,

We noticed there are hardcoded versions of browsers in the wdio configs.
Perhaps it makes sense to use `latest` instead - this will make sure you are always testing on the latest browser version.