### PR TITLE
Stop checking for emails on donation with credits / saved-info / rest…

### DIFF
--- a/features/donation-as-new-donor-restart-donation.feature
+++ b/features/donation-as-new-donor-restart-donation.feature
@@ -8,21 +8,17 @@ Feature: New donor: restarting donation completes successfully
         Given that I am on my chosen charity's Donate page
         When I enter an amount of £25000
         And I say no to Gift Aid
-        And I enter my name, email address and UK Visa card number
+        And I enter my name, an email address that does not receive email and UK Visa card number
         And I choose a preference for charity and TBG communications
         And I navigate back to the first step
         # Update donation amount by -1, relative to its initial value.
         And I update the amount to £24999
         And I say no to Gift Aid
-        And I enter my name, email address and UK Visa card number
+        And I enter my name, an email address that does not receive email and UK Visa card number
         And I choose a preference for charity and TBG communications
         And I press Donate
         When I wait a few seconds
         Then I should be redirected to a Thank You confirmation page with amount £24999
-        When I wait long enough for email processing
-        Then my last email should contain amount £24999
-        And my last email should contain the charity's custom thank you message
-        And my last email should contain the correct name
 
         ## Fee is calculated as round(round(24999*1.5/100+0.2)*1.2)
         And my charity has been charged a vat inclusive fee of £450.23

--- a/features/donation-with-credits.feature
+++ b/features/donation-with-credits.feature
@@ -26,7 +26,3 @@ Feature: Existing donor: credit donation completes successfully
         And I press Donate
         When I wait a few seconds
         Then I should be redirected to a Thank You confirmation page with the correct amount
-        When I wait long enough for email processing
-        Then my last email should contain the correct amounts
-        And my last email should contain the charity's custom thank you message
-        And my last email should contain the correct name

--- a/features/donation-with-saved-info.feature
+++ b/features/donation-with-saved-info.feature
@@ -23,7 +23,3 @@ Feature: Existing donor: saved payment method donation completes successfully
         And I press Donate
         When I wait a few seconds
         Then I should be redirected to a Thank You confirmation page with the correct amount
-        When I wait long enough for email processing
-        Then my last email should contain the correct amounts
-        And my last email should contain the charity's custom thank you message
-        And my last email should contain the correct name

--- a/steps/donation.ts
+++ b/steps/donation.ts
@@ -201,7 +201,20 @@ When(/I skip over (.+) step/, async (step: string) => {
 When(
     'I enter my name, email address and UK Visa card number',
     async () => {
-        donor = await page.populateNameAndEmail();
+        donor = await page.populateNameAndEmail({});
+        await page.populateStripePaymentDetails();
+        await page.progressToNextStep(false);
+    }
+);
+
+/**
+ * We have a limited allowance of test emails per month, so we don't want to test the email feature more than
+ * necessary.
+ */
+When(
+    'I enter my name, an email address that does not receive email and UK Visa card number',
+    async () => {
+        donor = await page.populateNameAndEmail({noSendEmail: true});
         await page.populateStripePaymentDetails();
         await page.progressToNextStep(false);
     }


### PR DESCRIPTION
…art donation scenarios

We already check the same email sending feature in the donor-then-register feature.

See https://github.com/thebiggive/mailer/pull/166