### PR TITLE
REG-41: Temporarily skip tests that rely on email deliverability

### DIFF
--- a/features/donation-as-new-donor-then-register.feature
+++ b/features/donation-as-new-donor-then-register.feature
@@ -1,3 +1,4 @@
+@skip()
 Feature: New donor: donation completes successfully and donor registers
 
     As a new donor

--- a/features/register-then-create-regular-mandate.feature
+++ b/features/register-then-create-regular-mandate.feature
@@ -1,3 +1,4 @@
+@skip()
 Feature: New donor registers and sets up new Regular Giving mandate
 
     As a new donor

--- a/features/submit-pledge.feature
+++ b/features/submit-pledge.feature
@@ -1,6 +1,7 @@
 # Terms checkbox is not currently select-able by our current WD.io selectors in Safari, and
 # we will probably replace this form soon enough that that isn't worth fixing.
-@skip(browserName="safari")
+#@skip(browserName="safari")
+@skip()
 Feature: Pledge form is submitted successfully
 
   As a pledger


### PR DESCRIPTION
Not working today in regtest env, should be restored on Sunday