### PR TITLE
Log last error message and wait 2x as long in `withPauseAndRetry()`

### DIFF
--- a/steps/donation.ts
+++ b/steps/donation.ts
@@ -21,7 +21,7 @@ import {
 } from '../support/check';
 import { clickBigGiveButtonWithOuterSelector, clickBigGiveButtonWithText } from '../support/action';
 import RegistrationPage from '../pages/RegistrationPage';
-import withRetryAndPause from '../support/withPauseAndRetry';
+import withPauseAndRetry from '../support/withPauseAndRetry';
 
 const stripeUseCreditsMessageSelector = '#useCreditsMessage';
 
@@ -404,7 +404,7 @@ Then(
     'my last email should contain a new monthly mandate confirmation showing amount £{int}',
     async (amount) => {
         const formattedAmount = `£${amount.toLocaleString('en-GB')}.00`;
-        withRetryAndPause({
+        withPauseAndRetry({
             callback: async () => {
                 if (!(await checkAnEmailBodyContainsText(
                     `Donation: <strong>${formattedAmount}</strong>`,
@@ -421,7 +421,7 @@ Then(
 When(
     'I register using the link in my donation thanks message',
     async () => {
-        const link = await withRetryAndPause({
+        const link = await withPauseAndRetry({
             callback: () => findAccountSetupLinkInRecentEmail(donor.email),
             predicate: (l) => !!l,
             label: 'FIND_LINK_IN_THANKS_MESSAGE',

--- a/support/withPauseAndRetry.ts
+++ b/support/withPauseAndRetry.ts
@@ -29,8 +29,9 @@ export default async function withPauseAndRetry<T>(
             lastError = error;
         }
 
-        const delaySeconds = 2 ** retryCount;
-        console.log(`${label} failed, pausing ${delaySeconds} seconds before retry`);
+        const lastMessage = lastError instanceof Error ? lastError.message : JSON.stringify(lastError);
+        const delaySeconds = 4 ** retryCount;
+        console.log(`${label} failed with ${lastMessage}, pausing ${delaySeconds} seconds before retry`);
         // eslint-disable-next-line no-await-in-loop,wdio/no-pause
         await browser.pause(delaySeconds * 1000);
         retryCount += 1;


### PR DESCRIPTION
Mostly of interest for Mailtrap email checking flakiness at the moment.

Also align fn name as used with the file name to avoid confusion.