### PR TITLE
Run tests in all browsers again; allow up to 2 parallel workers

### DIFF
--- a/wdio.testingbot-all.conf.cjs
+++ b/wdio.testingbot-all.conf.cjs
@@ -24,7 +24,7 @@ config.capabilities = [
         elementScrollBehavior: 1, // from bottom.
     },
 ];
-config.maxInstances = 1;
+config.maxInstances = 2;
 config.services.push('testingbot');
 
 config.path = '/wd/hub';

--- a/wdio.testingbot-all.conf.cjs
+++ b/wdio.testingbot-all.conf.cjs
@@ -13,16 +13,16 @@ config.capabilities = [
         version: '16', // 16.3 – older than the point releases which last reached iOS – as of April 2025
         build: config.build,
     },
-    // {
-    //     browserName: 'microsoftedge',
-    //     platform: 'WIN11',
-    //     version: 'latest',
-    //     build: config.build,
-    //     // MS Edge, like IE, seems to also have problems with scroll mgmt behaviour.
-    //     // https://stackoverflow.com/questions/52276194
-    //     // Modifying this flag resolved wrong elements getting some clicks in IE11.
-    //     elementScrollBehavior: 1, // from bottom.
-    // },
+    {
+        browserName: 'microsoftedge',
+        platform: 'WIN11',
+        version: 'latest',
+        build: config.build,
+        // MS Edge, like IE, seems to also have problems with scroll mgmt behaviour.
+        // https://stackoverflow.com/questions/52276194
+        // Modifying this flag resolved wrong elements getting some clicks in IE11.
+        elementScrollBehavior: 1, // from bottom.
+    },
 ];
 config.maxInstances = 1;
 config.services.push('testingbot');


### PR DESCRIPTION
Might well reintroduce occasions we exceed e.g. TestingBot limits while PR checks are running, but increasingly I think that's less bad than the whole suite being really slow.